### PR TITLE
Linting: Add StyleCop to API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
 
     steps:
       - checkout
-      - run: dotnet build TestSwitchApi\TestSwitchApi\TestSwitchApi.csproj
+      - run: dotnet build /warnaserror TestSwitchApi\TestSwitchApi\TestSwitchApi.csproj
+      - run: dotnet build /warnaserror TestSwitchApi\TestSwitchApi.Tests\TestSwitchApi.Tests.csproj
       - run: dotnet test TestSwitchApi\TestSwitchApi.Tests\TestSwitchApi.Tests.csproj
 
 

--- a/TestSwitchApi/TestSwitchApi.Tests/.ruleset
+++ b/TestSwitchApi/TestSwitchApi.Tests/.ruleset
@@ -1,0 +1,16 @@
+<RuleSet Name="Rules for TestSwitch-API" ToolsVersion="1.1.118">
+    <Rules AnalyzerId="Stylecop.Analyzers" RuleNamespace="Stylecop.Analyzers">
+        <!--See https://dotnetanalyzers.github.io/StyleCopAnalyzers/ for a dictionary of StyleCop rules.-->
+        <Rule Id="SA0001" Action="None"/>
+        <Rule Id="SA1003" Action="None"/> 
+        <Rule Id="SA1008" Action="None"/> 
+        <Rule Id="SA1009" Action="None"/>
+        <Rule Id="SA1101" Action="None"/>
+        <Rule Id="SA1110" Action="None"/>
+        <Rule Id="SA1111" Action="None"/>
+        <Rule Id="SA1309" Action="None"/>
+        <Rule Id="SA1310" Action="None"/>
+        <Rule Id="SA1516" Action="None"/>
+        <Rule Id="SA1633" Action="None"/>
+    </Rules>
+</RuleSet>

--- a/TestSwitchApi/TestSwitchApi.Tests/TestSwitchApi.Tests.csproj
+++ b/TestSwitchApi/TestSwitchApi.Tests/TestSwitchApi.Tests.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <CodeAnalysisRuleSet>.ruleset</CodeAnalysisRuleSet>
         <IsPackable>false</IsPackable>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/TestSwitchApi/TestSwitchApi.Tests/TestSwitchApi.Tests.csproj
+++ b/TestSwitchApi/TestSwitchApi.Tests/TestSwitchApi.Tests.csproj
@@ -2,8 +2,9 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-
+        <CodeAnalysisRuleSet>.ruleset</CodeAnalysisRuleSet>
         <IsPackable>false</IsPackable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
@@ -12,10 +13,15 @@
         <PackageReference Include="nunit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\TestSwitchApi\TestSwitchApi.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AdditionalFiles Include="stylecop.json" Link="stylecop.json" />
     </ItemGroup>
 
 </Project>

--- a/TestSwitchApi/TestSwitchApi.Tests/UnitTest1.cs
+++ b/TestSwitchApi/TestSwitchApi.Tests/UnitTest1.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 
 namespace TestSwitchApi.Tests
 {
-    public class Tests
+    public class UnitTest1
     {
         [SetUp]
         public void Setup()

--- a/TestSwitchApi/TestSwitchApi.Tests/stylecop.json
+++ b/TestSwitchApi/TestSwitchApi.Tests/stylecop.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+
+  "settings": {
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
+    },
+    "documentationRules": {
+      "documentationCulture": "en-GB",
+      "documentInterfaces": false,
+      "documentExposedElements": false,
+      "documentInternalElements": false,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false
+    }
+  }
+}

--- a/TestSwitchApi/TestSwitchApi.sln.DotSettings
+++ b/TestSwitchApi/TestSwitchApi.sln.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/ReadSettingsFromFileLevel/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/ReadSettingsFromFileLevel/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/TestSwitchApi/TestSwitchApi.sln.DotSettings
+++ b/TestSwitchApi/TestSwitchApi.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/ReadSettingsFromFileLevel/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/TestSwitchApi/TestSwitchApi/.ruleset
+++ b/TestSwitchApi/TestSwitchApi/.ruleset
@@ -1,0 +1,16 @@
+<RuleSet Name="Rules for TestSwitch-API" ToolsVersion="1.1.118">
+    <Rules AnalyzerId="Stylecop.Analyzers" RuleNamespace="Stylecop.Analyzers">
+        <!--See https://dotnetanalyzers.github.io/StyleCopAnalyzers/ for a dictionary of StyleCop rules.-->
+        <Rule Id="SA0001" Action="None"/>
+        <Rule Id="SA1003" Action="None"/>
+        <Rule Id="SA1008" Action="None"/>
+        <Rule Id="SA1009" Action="None"/>
+        <Rule Id="SA1101" Action="None"/>
+        <Rule Id="SA1110" Action="None"/>
+        <Rule Id="SA1111" Action="None"/>
+        <Rule Id="SA1309" Action="None"/>
+        <Rule Id="SA1310" Action="None"/>
+        <Rule Id="SA1516" Action="None"/>
+        <Rule Id="SA1633" Action="None"/>
+    </Rules>
+</RuleSet>

--- a/TestSwitchApi/TestSwitchApi/Controllers/WeatherForecastController.cs
+++ b/TestSwitchApi/TestSwitchApi/Controllers/WeatherForecastController.cs
@@ -7,22 +7,19 @@ using Microsoft.Extensions.Logging;
 
 namespace TestSwitchApi.Controllers
 {
-    //THIS CONTROLLER IS STOCK CODE SO DO NOT HESITATE TO DELETE WHEN FIRST CONTROLLER IS SET UP.
-    //CAN BE USED AS A TEMPLATE UNTIL THEN.
-    //Also delete the WeatherForecast.cs model when necessary.
-    
-    
+    // THIS CONTROLLER IS STOCK CODE SO DO NOT HESITATE TO DELETE WHEN FIRST CONTROLLER IS SET UP.
+    // CAN BE USED AS A TEMPLATE UNTIL THEN.
+    // Also delete the WeatherForecast.cs model when necessary.
     [ApiController]
     [Route("[controller]")]
     public class WeatherForecastController : ControllerBase
     {
         private static readonly string[] Summaries = new[]
         {
-            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
         };
 
         private readonly ILogger<WeatherForecastController> _logger;
-
         public WeatherForecastController(ILogger<WeatherForecastController> logger)
         {
             _logger = logger;
@@ -31,13 +28,22 @@ namespace TestSwitchApi.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
+            if (1 == 1)
+            {
+                var str = "f";
+                Console.WriteLine(str);
+            }
+
             var rng = new Random();
-            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
-                {
-                    Date = DateTime.Now.AddDays(index),
-                    TemperatureC = rng.Next(-20, 55),
-                    Summary = Summaries[rng.Next(Summaries.Length)]
-                })
+            return Enumerable.Range(1, 5).Select
+                (
+                    index => new WeatherForecast
+                    {
+                        Date = DateTime.Now.AddDays(index),
+                        TemperatureC = rng.Next(-20, 55),
+                        Summary = Summaries[rng.Next(Summaries.Length)],
+                    }
+                )
                 .ToArray();
         }
     }

--- a/TestSwitchApi/TestSwitchApi/TestSwitchApi.csproj
+++ b/TestSwitchApi/TestSwitchApi/TestSwitchApi.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <CodeAnalysisRuleSet>.ruleset</CodeAnalysisRuleSet>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/TestSwitchApi/TestSwitchApi/TestSwitchApi.csproj
+++ b/TestSwitchApi/TestSwitchApi/TestSwitchApi.csproj
@@ -2,11 +2,20 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <CodeAnalysisRuleSet>.ruleset</CodeAnalysisRuleSet>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
       <Folder Include="Services" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <AdditionalFiles Include="stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
 
 </Project>

--- a/TestSwitchApi/TestSwitchApi/stylecop.json
+++ b/TestSwitchApi/TestSwitchApi/stylecop.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+
+  "settings": {
+    "orderingRules": {
+      "usingDirectivesPlacement": "outsideNamespace"
+    },
+    "documentationRules": {
+      "documentationCulture": "en-GB",
+      "documentInterfaces": false,
+      "documentExposedElements": false,
+      "documentInternalElements": false,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false
+    }
+  }
+}

--- a/TestSwitchApi/readme.md
+++ b/TestSwitchApi/readme.md
@@ -10,4 +10,5 @@ This is to ensure Circle CI fails the build if there are lint errors.
 This can be changed during dev if it's a pain by setting the value of `TreatWarningsAsErrors` to false.
 
 I'd recommend using auto-format (`ctrl+shift+L` is the default Rider command, or go to Code > Reformat Code) to auto-format files if StyleCop is complaining about formatting.  
-If Rider disagrees with StyleCop as to how to format code, make sure that Rider's code style settings match StyleCop's settings (Settings (`ctrl+shift+s`) > Editor > Code Style > C#).
+If Rider disagrees with StyleCop as to how to format code, make sure that Rider's code style settings match StyleCop's settings (Settings (`ctrl+shift+s`) > Editor > Code Style > C#).  
+I've made code style settings that seem to agree with StyleCop which are encapsulated in TestSwitchApi.sln.DotSettings. This is checked into git, so it should take effect across the whole team.

--- a/TestSwitchApi/readme.md
+++ b/TestSwitchApi/readme.md
@@ -3,12 +3,11 @@ This is the API for the TestSwitch.
 
 ### Linting
 We're using StyleCop to lint the project.  
-Some StyleCop rules are disabled in the .ruleset files in each project. 
- 
-Compile-time warnings are set to be treated as errors in the csproj files.  
-This is to ensure Circle CI fails the build if there are lint errors.  
-This can be changed during dev if it's a pain by setting the value of `TreatWarningsAsErrors` to false.
+Some StyleCop rules are disabled in the .ruleset files in each project.
 
-I'd recommend using auto-format (`ctrl+shift+L` is the default Rider command, or go to Code > Reformat Code) to auto-format files if StyleCop is complaining about formatting.  
-If Rider disagrees with StyleCop as to how to format code, make sure that Rider's code style settings match StyleCop's settings (Settings (`ctrl+shift+s`) > Editor > Code Style > C#).  
-I've made code style settings that seem to agree with StyleCop which are encapsulated in TestSwitchApi.sln.DotSettings. This is checked into git, so it should take effect across the whole team.
+I'd recommend using auto-format (`ctrl+shift+L` is the default Rider command, or go to Code > Reformat Code) to auto-format files if StyleCop is complaining about formatting.
+  
+If Rider disagrees with StyleCop as to how to format code, make sure that Rider's code style settings match StyleCop's settings (Settings (`ctrl+shift+s`) > Editor > Code Style > C#).
+  
+I've made code style settings that seem to agree with StyleCop which are encapsulated in TestSwitchApi.sln.DotSettings.  
+This is checked into git, so it should take effect across the whole team.

--- a/TestSwitchApi/readme.md
+++ b/TestSwitchApi/readme.md
@@ -1,0 +1,13 @@
+# TestSwitch API
+This is the API for the TestSwitch.
+
+### Linting
+We're using StyleCop to lint the project.  
+Some StyleCop rules are disabled in the .ruleset files in each project. 
+ 
+Compile-time warnings are set to be treated as errors in the csproj files.  
+This is to ensure Circle CI fails the build if there are lint errors.  
+This can be changed during dev if it's a pain by setting the value of `TreatWarningsAsErrors` to false.
+
+I'd recommend using auto-format (`ctrl+shift+L` is the default Rider command, or go to Code > Reformat Code) to auto-format files if StyleCop is complaining about formatting.  
+If Rider disagrees with StyleCop as to how to format code, make sure that Rider's code style settings match StyleCop's settings (Settings (`ctrl+shift+s`) > Editor > Code Style > C#).


### PR DESCRIPTION
I've added StyleCop to the API to lint for us.
There are a couple of slightly controversial rules that StyleCop applies, but I think I've disabled pretty much all of them.
This pull request will also merge in a DotSettings file which should ensure our Rider C# style is the same for everyone. I think I've set it up so that it agrees with StyleCop, but let me know if it doesn't.